### PR TITLE
Add generation of basic interface declaration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,10 +17,15 @@ stages:
       vmImage: windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: 'Install the .NET Core SDK'
+      displayName: 'Install the .NET Core SDK (5.0.x)'
       inputs:
         packageType: 'sdk'
         version: '5.0.x'
+    - task: UseDotNet@2
+      displayName: 'Install the .NET Core SDK (3.1.x)'
+      inputs:
+        packageType: 'sdk'
+        version: '3.1.x'
     - task: DotNetCoreCLI@2
       displayName: 'Build & Pack the libraries'
       inputs:

--- a/src/MGR.AsyncContract.SourceGenerator/AssemblyInfo.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleToAttribute("MGR.AsyncContract.SourceGenerator.UnitTests")]

--- a/src/MGR.AsyncContract.SourceGenerator/AsyncContractSourceGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/AsyncContractSourceGenerator.cs
@@ -5,9 +5,20 @@ namespace MGR.AsyncContract.SourceGenerator
     [Generator]
     public class AsyncContractSourceGenerator : ISourceGenerator
     {
+        public void Initialize(GeneratorInitializationContext context) => context.RegisterForSyntaxNotifications(() => new ServiceContractSyntaxReceiver());
         public void Execute(GeneratorExecutionContext context)
-        { }
-        public void Initialize(GeneratorInitializationContext context)
-        { }
+        {
+            if (context.SyntaxReceiver is not ServiceContractSyntaxReceiver receiver)
+            {
+                return;
+            }
+            var interfaceGenerator = new InterfaceGenerator(context.Compilation);
+            foreach (var originalInterfaceDeclaration in receiver.Targets)
+            {
+                var generationResult = interfaceGenerator.Generate(originalInterfaceDeclaration);
+
+                context.AddSource(generationResult.TargetName, generationResult.SourceCode);
+            }
+        }
     }
 }

--- a/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.CodeAnalysis;
+using System.Linq;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal class AttributeGenerator
+    {
+        public string Generate(AttributeData attributeData)
+        {
+            var attributeClass = attributeData.AttributeClass;
+            if (attributeClass is null)
+            {
+                return string.Empty;
+            }
+            var fullName = attributeClass.ContainingNamespace.GetNamespaceAsPrefix() + attributeClass.Name;
+            var namedParameters = string.Join(", ",
+                attributeData.NamedArguments.Select(namedArgument => namedArgument.Key + " = " + namedArgument.Value.GetValue())
+                );
+            var constructorParameters = namedParameters;
+
+            return $"[{fullName}({constructorParameters})]";
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
@@ -14,16 +14,16 @@ namespace MGR.AsyncContract.SourceGenerator
             _operationContractSymbol = compilation.GetTypeByMetadataName(Constants.FullyQualifiedOperationContractAttribute)
     ?? throw new InvalidOperationException("Unable to find the attribute System.ServiceModel.OperationContractAttribute");
         }
-        public string GenerateInterfaceAttribute(AttributeData attributeData) => Generate(attributeData, NoOp);
+        public string GenerateAttribute(AttributeData attributeData) => Generate(attributeData, NoOp);
 
-        public string GenerateMethodAttribute(AttributeData attributeData, ServiceContractInformation serviceContractInformation, string methodName)
+        public string GenerateOperationContractAttribute(AttributeData attributeData, ServiceContractInformation serviceContractInformation, string methodName)
         {
             var attributeClass = attributeData.AttributeClass;
             if (attributeClass is null)
             {
                 return string.Empty;
             }
-            Func<ImmutableArray<KeyValuePair<string, TypedConstant>>, IEnumerable<KeyValuePair<string, string>>> transformOperation = _operationContractSymbol.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default) ? arguments => TransformNamedAttributes(arguments, serviceContractInformation, methodName) : NoOp;
+            Func<ImmutableArray<KeyValuePair<string, TypedConstant>>, IEnumerable<KeyValuePair<string, string>>> transformOperation = IsOperationContractAttribute(attributeData) ? arguments => TransformNamedAttributes(arguments, serviceContractInformation, methodName) : NoOp;
 
             return Generate(attributeData, transformOperation);
         }
@@ -61,5 +61,6 @@ namespace MGR.AsyncContract.SourceGenerator
                 yield return new KeyValuePair<string, string>("Action", $@"""{serviceContractInformation.RootNamespace}/{serviceContractInformation.ServiceName}/{methodName}""");
             }
         }
+        public bool IsOperationContractAttribute(AttributeData attribute) => _operationContractSymbol.Equals(attribute.AttributeClass, SymbolEqualityComparer.Default);
     }
 }

--- a/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
@@ -1,24 +1,65 @@
 ﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace MGR.AsyncContract.SourceGenerator
 {
     internal class AttributeGenerator
     {
-        public string Generate(AttributeData attributeData)
+        private readonly INamedTypeSymbol _operationContractSymbol;
+        public AttributeGenerator(Compilation compilation)
+        {
+            _operationContractSymbol = compilation.GetTypeByMetadataName(Constants.FullyQualifiedOperationContractAttribute)
+    ?? throw new InvalidOperationException("Unable to find the attribute System.ServiceModel.OperationContractAttribute");
+        }
+        public string GenerateInterfaceAttribute(AttributeData attributeData) => Generate(attributeData, NoOp);
+
+        public string GenerateMethodAttribute(AttributeData attributeData, ServiceContractInformation serviceContractInformation, string methodName)
         {
             var attributeClass = attributeData.AttributeClass;
             if (attributeClass is null)
             {
                 return string.Empty;
             }
+            Func<ImmutableArray<KeyValuePair<string, TypedConstant>>, IEnumerable<KeyValuePair<string, string>>> transformOperation = _operationContractSymbol.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default) ? arguments => TransformNamedAttributes(arguments, serviceContractInformation, methodName) : NoOp;
+
+            return Generate(attributeData, transformOperation);
+        }
+        private string Generate(AttributeData attributeData, Func<ImmutableArray<KeyValuePair<string, TypedConstant>>, IEnumerable<KeyValuePair<string, string>>> transformOperation)
+        {
+            var attributeClass = attributeData.AttributeClass;
+            if (attributeClass is null)
+            {
+                return string.Empty;
+            }
+            var namedArguments = transformOperation(attributeData.NamedArguments);
             var fullName = attributeClass.ContainingNamespace.GetNamespaceAsPrefix() + attributeClass.Name;
             var namedParameters = string.Join(", ",
-                attributeData.NamedArguments.Select(namedArgument => namedArgument.Key + " = " + namedArgument.Value.GetValue())
+                namedArguments.Select(namedArgument => namedArgument.Key + " = " + namedArgument.Value)
                 );
             var constructorParameters = namedParameters;
 
             return $"[{fullName}({constructorParameters})]";
+        }
+        private static IEnumerable<KeyValuePair<string, string>> NoOp(ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments) => namedArguments.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value.GetValue()));
+
+        private IEnumerable<KeyValuePair<string, string>> TransformNamedAttributes(ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments, ServiceContractInformation serviceContractInformation, string methodName)
+        {
+            var addActionArgument = true;
+            foreach (var argument in namedArguments)
+            {
+                if (argument.Key == "Action")
+                {
+                    addActionArgument = false;
+                }
+                yield return new KeyValuePair<string, string>(argument.Key, argument.Value.GetValue());
+            }
+            if (addActionArgument)
+            {
+                yield return new KeyValuePair<string, string>("Action", $@"""{serviceContractInformation.RootNamespace}/{serviceContractInformation.ServiceName}/{methodName}""");
+            }
         }
     }
 }

--- a/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/AttributeGenerator.cs
@@ -58,7 +58,7 @@ namespace MGR.AsyncContract.SourceGenerator
             }
             if (addActionArgument)
             {
-                yield return new KeyValuePair<string, string>("Action", $@"""{serviceContractInformation.RootNamespace}/{serviceContractInformation.ServiceName}/{methodName}""");
+                yield return new KeyValuePair<string, string>("Action", $@"""{serviceContractInformation.GenerateActionValueForMethod(methodName)}""");
             }
         }
         public bool IsOperationContractAttribute(AttributeData attribute) => _operationContractSymbol.Equals(attribute.AttributeClass, SymbolEqualityComparer.Default);

--- a/src/MGR.AsyncContract.SourceGenerator/CodeBlock.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/CodeBlock.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal struct CodeBlock : IDisposable
+    {
+        private readonly CodeBuilder _codeBuilder;
+
+        public CodeBlock(CodeBuilder codeBuilder)
+        {
+            _codeBuilder = codeBuilder;
+        }
+
+        public void Dispose()
+        {
+            _codeBuilder.DecreaseIndentation();
+            _codeBuilder.AppendLine("}");
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/CodeBuilder.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/CodeBuilder.cs
@@ -6,6 +6,7 @@ namespace MGR.AsyncContract.SourceGenerator
 {
     internal class CodeBuilder
     {
+        private static string[] NewLineSeparators = new[] { Environment.NewLine };
         private readonly StringBuilder _codeBuilder = new();
         private int _currentIndentation = 0;
 
@@ -21,7 +22,7 @@ namespace MGR.AsyncContract.SourceGenerator
         }
         public IDisposable StartNamespace(INamespaceSymbol namespaceSymbol)
         {
-            if(namespaceSymbol.IsGlobalNamespace)
+            if (namespaceSymbol.IsGlobalNamespace)
             {
                 return EmptyDisposable.Instance;
             }
@@ -37,13 +38,20 @@ namespace MGR.AsyncContract.SourceGenerator
         }
         public CodeBuilder AppendLine(string line)
         {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return this;
+            }
             var indentation = string.Empty;
             if (_currentIndentation > 0)
             {
                 indentation = new string(' ', _currentIndentation * 4);
             }
-            _codeBuilder.Append(indentation)
-                .AppendLine(line);
+            foreach (var singleLine in line.Split(NewLineSeparators, StringSplitOptions.None))
+            {
+                _codeBuilder.Append(indentation)
+                    .AppendLine(singleLine);
+            }
             return this;
         }
 

--- a/src/MGR.AsyncContract.SourceGenerator/CodeBuilder.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/CodeBuilder.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Text;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal class CodeBuilder
+    {
+        private readonly StringBuilder _codeBuilder = new();
+        private int _currentIndentation = 0;
+
+        public CodeBuilder IncreaseIndentation()
+        {
+            _currentIndentation++;
+            return this;
+        }
+        public CodeBuilder DecreaseIndentation()
+        {
+            _currentIndentation--;
+            return this;
+        }
+        public IDisposable StartNamespace(INamespaceSymbol namespaceSymbol)
+        {
+            if(namespaceSymbol.IsGlobalNamespace)
+            {
+                return EmptyDisposable.Instance;
+            }
+            return StartBlock($"namespace {namespaceSymbol.ToDisplayString()}");
+        }
+
+        public CodeBlock StartBlock(string line)
+        {
+            AppendLine(line);
+            AppendLine("{");
+            IncreaseIndentation();
+            return new(this);
+        }
+        public CodeBuilder AppendLine(string line)
+        {
+            var indentation = string.Empty;
+            if (_currentIndentation > 0)
+            {
+                indentation = new string(' ', _currentIndentation * 4);
+            }
+            _codeBuilder.Append(indentation)
+                .AppendLine(line);
+            return this;
+        }
+
+        public string Build() => _codeBuilder.ToString();
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/Constants.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/Constants.cs
@@ -1,0 +1,12 @@
+﻿namespace MGR.AsyncContract.SourceGenerator
+{
+    internal static class Constants
+    {
+        private const string Namespace = "System.ServiceModel";
+
+        public const string ServiceContract = "ServiceContract";
+        public const string FullyQualifiedServiceContract = Namespace + "." + ServiceContract;
+        public const string ServiceContractAttribute = ServiceContract + "Attribute";
+        public const string FullyQualifiedServiceContractAttribute = Namespace + "." + ServiceContractAttribute;
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/Constants.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/Constants.cs
@@ -8,5 +8,10 @@
         public const string FullyQualifiedServiceContract = Namespace + "." + ServiceContract;
         public const string ServiceContractAttribute = ServiceContract + "Attribute";
         public const string FullyQualifiedServiceContractAttribute = Namespace + "." + ServiceContractAttribute;
+
+        public const string OperationContract = "OperationContract";
+        public const string FullyQualifiedOperationContract = Namespace + "." + OperationContract;
+        public const string OperationContractAttribute = OperationContract + "Attribute";
+        public const string FullyQualifiedOperationContractAttribute = Namespace + "." + OperationContractAttribute;
     }
 }

--- a/src/MGR.AsyncContract.SourceGenerator/EmptyDisposable.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/EmptyDisposable.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal class EmptyDisposable : IDisposable
+    {
+        private EmptyDisposable() { }
+        public static EmptyDisposable Instance { get; } = new();
+        public void Dispose() { }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/Extensions/AttributeSyntaxExtensions.cs
@@ -12,5 +12,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 || attributeName == Constants.FullyQualifiedServiceContractAttribute
                 || attributeName == Constants.ServiceContractAttribute;
         }
+        public static bool IsOperationContract(this AttributeSyntax attributeSyntax)
+        {
+            var attributeName = attributeSyntax.Name.ToString();
+            return attributeName == Constants.OperationContract
+                || attributeName == Constants.FullyQualifiedOperationContract
+                || attributeName == Constants.FullyQualifiedOperationContractAttribute
+                || attributeName == Constants.OperationContractAttribute;
+        }
     }
 }

--- a/src/MGR.AsyncContract.SourceGenerator/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/Extensions/AttributeSyntaxExtensions.cs
@@ -1,0 +1,16 @@
+﻿using MGR.AsyncContract.SourceGenerator;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    internal static class AttributeSyntaxExtensions
+    {
+        public static bool IsServiceContract(this AttributeSyntax attributeSyntax)
+        {
+            var attributeName = attributeSyntax.Name.ToString();
+            return attributeName == Constants.ServiceContract
+                || attributeName == Constants.FullyQualifiedServiceContract
+                || attributeName == Constants.FullyQualifiedServiceContractAttribute
+                || attributeName == Constants.ServiceContractAttribute;
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/Extensions/NamespaceSymbolExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.CodeAnalysis
+{
+    internal static class NamespaceSymbolExtensions
+    {
+        public static string GetNamespaceAsPrefix(this INamespaceSymbol source)
+        {
+            if (source.IsGlobalNamespace)
+            {
+                return string.Empty;
+            }
+            return source.ToDisplayString() + ".";
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/Extensions/TypedConstantExtensions.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/Extensions/TypedConstantExtensions.cs
@@ -1,0 +1,38 @@
+﻿namespace Microsoft.CodeAnalysis
+{
+    internal static class TypedConstantExtensions
+    {
+        public static string GetValue(this TypedConstant source)
+        {
+            if (source.IsNull)
+            {
+                return "null";
+            }
+            switch (source.Kind)
+            {
+                case TypedConstantKind.Primitive:
+                    return ConvertFromPrimitive(source);
+                case TypedConstantKind.Enum:
+                    return ConvertFromEnum(source);
+                case TypedConstantKind.Error:
+                case TypedConstantKind.Type:
+                case TypedConstantKind.Array:
+                default:
+                    return source.Value!.ToString();
+            }
+        }
+
+        private static string ConvertFromEnum(TypedConstant source) => "(" + source.Type!.ContainingNamespace.GetNamespaceAsPrefix() + source.Type.Name + ")" + source.Value;
+
+        private static string ConvertFromPrimitive(TypedConstant source)
+        {
+            switch (source.Type!.SpecialType)
+            {
+                case SpecialType.System_String:
+                    return "\"" + source.Value + "\"";
+                default:
+                    return source.Value!.ToString();
+            }
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/GenerationResult.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/GenerationResult.cs
@@ -1,0 +1,13 @@
+﻿namespace MGR.AsyncContract.SourceGenerator
+{
+    internal class GenerationResult
+    {
+        public GenerationResult(string targetName, string sourceCode)
+        {
+            SourceCode = sourceCode;
+            TargetName = targetName;
+        }
+        public string SourceCode { get; }
+        public string TargetName { get; }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal class InterfaceGenerator
+    {
+        private readonly Compilation _compilation;
+
+        public InterfaceGenerator(Compilation compilation)
+        {
+            _compilation = compilation;
+        }
+
+        internal GenerationResult Generate(InterfaceDeclarationSyntax originalInterfaceDeclaration)
+        {
+            var model = _compilation.GetSemanticModel(originalInterfaceDeclaration.SyntaxTree);
+            var source = model.GetDeclaredSymbol(originalInterfaceDeclaration) as ITypeSymbol;
+            if (source is null)
+            {
+                return new GenerationResult(Guid.NewGuid().ToString() + ".g.cs", string.Empty);
+            }
+            var originalInterfaceName = source.Name;
+            return new GenerationResult(originalInterfaceName + "Async.g.cs", @$"public interface {originalInterfaceName}Async
+{{
+}}");
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
@@ -53,7 +53,7 @@ namespace MGR.AsyncContract.SourceGenerator
             sourceCodeBuilder.AppendLine($@"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", ""{ typeof(AsyncContractSourceGenerator).Assembly.GetName().Version }"")]");
             foreach (var attributeData in interfaceAttributes)
             {
-                sourceCodeBuilder.AppendLine(_attributeGenerator.GenerateInterfaceAttribute(attributeData));
+                sourceCodeBuilder.AppendLine(_attributeGenerator.GenerateAttribute(attributeData));
             }
         }
 

--- a/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
@@ -1,37 +1,54 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
-using System.Text;
+using System.Linq;
 
 namespace MGR.AsyncContract.SourceGenerator
 {
     internal class InterfaceGenerator
     {
         private readonly Compilation _compilation;
+        private readonly AttributeGenerator _attributeGenerator;
 
         public InterfaceGenerator(Compilation compilation)
         {
             _compilation = compilation;
+            _attributeGenerator = new();
         }
 
         internal GenerationResult Generate(InterfaceDeclarationSyntax originalInterfaceDeclaration)
         {
             var model = _compilation.GetSemanticModel(originalInterfaceDeclaration.SyntaxTree);
-            var source = model.GetDeclaredSymbol(originalInterfaceDeclaration) as ITypeSymbol;
-            if (source is null)
+            var interfaceSource = model.GetDeclaredSymbol(originalInterfaceDeclaration) as ITypeSymbol;
+            if (interfaceSource is null)
             {
                 return new GenerationResult(Guid.NewGuid().ToString() + ".g.cs", string.Empty);
             }
-            var originalInterfaceName = source.Name;
-            var sourceCodeBuilder = GenerateNamespace(originalInterfaceDeclaration, source);
-            return new GenerationResult(originalInterfaceName + "Async.g.cs", sourceCodeBuilder.Build()) ;
+            var originalInterfaceName = interfaceSource.Name;
+            var sourceCodeBuilder = GenerateNamespace(originalInterfaceDeclaration, interfaceSource);
+            var namespaceSymbol = interfaceSource.ContainingNamespace;
+            var namespacePrefix = namespaceSymbol.IsGlobalNamespace ? "" : namespaceSymbol.ToDisplayString() + ".";
+            return new GenerationResult(namespacePrefix + originalInterfaceName + "Async.g.cs", sourceCodeBuilder.Build());
         }
 
         private CodeBuilder GenerateNamespace(InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)
         {
             var sourceCodeBuilder = new CodeBuilder();
             using var namespaceBlock = sourceCodeBuilder.StartNamespace(interfaceTypeSymbol.ContainingNamespace);
+            GenerateAttributes(sourceCodeBuilder, interfaceTypeSymbol, originalInterfaceDeclaration);
             return GenerateTypeDeclaration(sourceCodeBuilder, originalInterfaceDeclaration, interfaceTypeSymbol);
+        }
+
+        private void GenerateAttributes(CodeBuilder sourceCodeBuilder, ITypeSymbol interfaceTypeSymbol, InterfaceDeclarationSyntax originalInterfaceDeclaration)
+        {
+            sourceCodeBuilder.AppendLine($@"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", ""{ typeof(AsyncContractSourceGenerator).Assembly.GetName().Version }"")]");
+            var attributesData = interfaceTypeSymbol.GetAttributes();
+            var attrData = attributesData.First();
+            var allAttributes = originalInterfaceDeclaration.AttributeLists.SelectMany(attributes => attributes.Attributes);
+            foreach (var attributeData in attributesData)
+            {
+                sourceCodeBuilder.AppendLine(_attributeGenerator.Generate(attributeData));
+            }
         }
 
         private CodeBuilder GenerateTypeDeclaration(CodeBuilder sourceCodeBuilder, InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)

--- a/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace MGR.AsyncContract.SourceGenerator
@@ -9,11 +10,16 @@ namespace MGR.AsyncContract.SourceGenerator
     {
         private readonly Compilation _compilation;
         private readonly AttributeGenerator _attributeGenerator;
+        private readonly MethodGenerator _methodGenerator;
+        private readonly INamedTypeSymbol _serviceContractSymbol;
 
         public InterfaceGenerator(Compilation compilation)
         {
             _compilation = compilation;
-            _attributeGenerator = new();
+            _attributeGenerator = new(compilation);
+            _methodGenerator = new(compilation, _attributeGenerator);
+            _serviceContractSymbol = compilation.GetTypeByMetadataName(Constants.FullyQualifiedServiceContractAttribute)
+    ?? throw new InvalidOperationException("Unable to find the attribute System.ServiceModel.ServiceContractAttribute");
         }
 
         internal GenerationResult Generate(InterfaceDeclarationSyntax originalInterfaceDeclaration)
@@ -25,35 +31,39 @@ namespace MGR.AsyncContract.SourceGenerator
                 return new GenerationResult(Guid.NewGuid().ToString() + ".g.cs", string.Empty);
             }
             var originalInterfaceName = interfaceSource.Name;
-            var sourceCodeBuilder = GenerateNamespace(originalInterfaceDeclaration, interfaceSource);
+            var sourceCodeBuilder = GenerateNamespace(model, originalInterfaceDeclaration, interfaceSource);
             var namespaceSymbol = interfaceSource.ContainingNamespace;
             var namespacePrefix = namespaceSymbol.IsGlobalNamespace ? "" : namespaceSymbol.ToDisplayString() + ".";
             return new GenerationResult(namespacePrefix + originalInterfaceName + "Async.g.cs", sourceCodeBuilder.Build());
         }
 
-        private CodeBuilder GenerateNamespace(InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)
+        private CodeBuilder GenerateNamespace(SemanticModel semanticModel, InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)
         {
             var sourceCodeBuilder = new CodeBuilder();
             using var namespaceBlock = sourceCodeBuilder.StartNamespace(interfaceTypeSymbol.ContainingNamespace);
-            GenerateAttributes(sourceCodeBuilder, interfaceTypeSymbol, originalInterfaceDeclaration);
-            return GenerateTypeDeclaration(sourceCodeBuilder, originalInterfaceDeclaration, interfaceTypeSymbol);
+            var interfaceAttributes = interfaceTypeSymbol.GetAttributes();
+            GenerateAttributes(sourceCodeBuilder, interfaceAttributes);
+            var serviceContractAttribute = interfaceAttributes.Single(attr => _serviceContractSymbol.Equals(attr.AttributeClass, SymbolEqualityComparer.Default));
+            var serviceContractInformation = ServiceContractInformation.Parse(serviceContractAttribute, interfaceTypeSymbol.Name);
+            return GenerateTypeDeclaration(sourceCodeBuilder, semanticModel, originalInterfaceDeclaration, interfaceTypeSymbol, serviceContractInformation);
         }
 
-        private void GenerateAttributes(CodeBuilder sourceCodeBuilder, ITypeSymbol interfaceTypeSymbol, InterfaceDeclarationSyntax originalInterfaceDeclaration)
+        private void GenerateAttributes(CodeBuilder sourceCodeBuilder, IEnumerable<AttributeData> interfaceAttributes)
         {
             sourceCodeBuilder.AppendLine($@"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", ""{ typeof(AsyncContractSourceGenerator).Assembly.GetName().Version }"")]");
-            var attributesData = interfaceTypeSymbol.GetAttributes();
-            var attrData = attributesData.First();
-            var allAttributes = originalInterfaceDeclaration.AttributeLists.SelectMany(attributes => attributes.Attributes);
-            foreach (var attributeData in attributesData)
+            foreach (var attributeData in interfaceAttributes)
             {
-                sourceCodeBuilder.AppendLine(_attributeGenerator.Generate(attributeData));
+                sourceCodeBuilder.AppendLine(_attributeGenerator.GenerateInterfaceAttribute(attributeData));
             }
         }
 
-        private CodeBuilder GenerateTypeDeclaration(CodeBuilder sourceCodeBuilder, InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)
+        private CodeBuilder GenerateTypeDeclaration(CodeBuilder sourceCodeBuilder, SemanticModel semanticModel, InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol, ServiceContractInformation serviceContractInformation)
         {
             using var typeDeclarationBlock = sourceCodeBuilder.StartBlock(@$"public interface {interfaceTypeSymbol.Name}Async");
+            foreach (var methodDeclaration in originalInterfaceDeclaration.Members.OfType<MethodDeclarationSyntax>())
+            {
+                sourceCodeBuilder.AppendLine(_methodGenerator.Generate(semanticModel, methodDeclaration, serviceContractInformation));
+            }
             return sourceCodeBuilder;
         }
     }

--- a/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/InterfaceGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Text;
 
 namespace MGR.AsyncContract.SourceGenerator
 {
@@ -22,9 +23,21 @@ namespace MGR.AsyncContract.SourceGenerator
                 return new GenerationResult(Guid.NewGuid().ToString() + ".g.cs", string.Empty);
             }
             var originalInterfaceName = source.Name;
-            return new GenerationResult(originalInterfaceName + "Async.g.cs", @$"public interface {originalInterfaceName}Async
-{{
-}}");
+            var sourceCodeBuilder = GenerateNamespace(originalInterfaceDeclaration, source);
+            return new GenerationResult(originalInterfaceName + "Async.g.cs", sourceCodeBuilder.Build()) ;
+        }
+
+        private CodeBuilder GenerateNamespace(InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)
+        {
+            var sourceCodeBuilder = new CodeBuilder();
+            using var namespaceBlock = sourceCodeBuilder.StartNamespace(interfaceTypeSymbol.ContainingNamespace);
+            return GenerateTypeDeclaration(sourceCodeBuilder, originalInterfaceDeclaration, interfaceTypeSymbol);
+        }
+
+        private CodeBuilder GenerateTypeDeclaration(CodeBuilder sourceCodeBuilder, InterfaceDeclarationSyntax originalInterfaceDeclaration, ITypeSymbol interfaceTypeSymbol)
+        {
+            using var typeDeclarationBlock = sourceCodeBuilder.StartBlock(@$"public interface {interfaceTypeSymbol.Name}Async");
+            return sourceCodeBuilder;
         }
     }
 }

--- a/src/MGR.AsyncContract.SourceGenerator/MGR.AsyncContract.SourceGenerator.csproj
+++ b/src/MGR.AsyncContract.SourceGenerator/MGR.AsyncContract.SourceGenerator.csproj
@@ -2,10 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+      <LangVersion>latest</LangVersion>
+      <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/src/MGR.AsyncContract.SourceGenerator/MethodGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/MethodGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
 using System.Text;
 
 namespace MGR.AsyncContract.SourceGenerator
@@ -19,14 +20,31 @@ namespace MGR.AsyncContract.SourceGenerator
         {
             if (semanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol methodSymbol)
             {
-                return "";
+                return string.Empty;
             }
+            var hasOperationContract = false;
             var methodBuilder = new StringBuilder();
             foreach (var attribute in methodSymbol.GetAttributes())
             {
-                methodBuilder.AppendLine(_attributeGenerator.GenerateMethodAttribute(attribute, serviceContractInformation, methodSymbol.Name));
-            }
+                if (_attributeGenerator.IsOperationContractAttribute(attribute))
+                {
+                    hasOperationContract = true;
+                    methodBuilder.AppendLine(_attributeGenerator.GenerateOperationContractAttribute(attribute, serviceContractInformation, methodSymbol.Name));
+                }
+                else
+                {
+                    methodBuilder.AppendLine(_attributeGenerator.GenerateAttribute(attribute));
 
+                }
+            }
+            if (!hasOperationContract)
+            {
+                return string.Empty;
+            }
+            methodBuilder.AppendFormat("System.Threading.Tasks.Task{0} {1}Async({2});",
+                methodSymbol.ReturnsVoid ? "" : $"<{ methodSymbol.ReturnType.ToDisplayString() }>",
+                methodSymbol.Name,
+                string.Join(", ", methodSymbol.Parameters.Select(parameter => parameter.ToDisplayString() + " " + parameter.Name)));
             return methodBuilder.ToString();
         }
     }

--- a/src/MGR.AsyncContract.SourceGenerator/MethodGenerator.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/MethodGenerator.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal class MethodGenerator
+    {
+        private readonly Compilation _compilation;
+        private readonly AttributeGenerator _attributeGenerator;
+
+        public MethodGenerator(Compilation compilation, AttributeGenerator attributeGenerator)
+        {
+            _compilation = compilation;
+            _attributeGenerator = attributeGenerator;
+        }
+        public string Generate(SemanticModel semanticModel, MethodDeclarationSyntax methodDeclaration, ServiceContractInformation serviceContractInformation)
+        {
+            if (semanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol methodSymbol)
+            {
+                return "";
+            }
+            var methodBuilder = new StringBuilder();
+            foreach (var attribute in methodSymbol.GetAttributes())
+            {
+                methodBuilder.AppendLine(_attributeGenerator.GenerateMethodAttribute(attribute, serviceContractInformation, methodSymbol.Name));
+            }
+
+            return methodBuilder.ToString();
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/ServiceContractInformation.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/ServiceContractInformation.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    public class ServiceContractInformation
+    {
+        public ServiceContractInformation(string rootNamespace, string serviceName)
+        {
+            RootNamespace = rootNamespace;
+            ServiceName = serviceName;
+        }
+
+        public string RootNamespace { get; }
+        public string ServiceName { get; }
+
+        public static ServiceContractInformation Parse(AttributeData serviceContractAttribute, string interfaceName)
+        {
+            string rootNamespace = "http://tempuri.org";
+            string serviceName = interfaceName;
+            foreach (var argument in serviceContractAttribute.NamedArguments)
+            {
+                if (argument.Key == "Namespace")
+                {
+                    rootNamespace = argument.Value.GetValue();
+                }
+                if (argument.Key == "Name")
+                {
+                    serviceName = argument.Value.GetValue();
+                }
+            }
+            return new ServiceContractInformation(rootNamespace, serviceName);
+        }
+    }
+}

--- a/src/MGR.AsyncContract.SourceGenerator/ServiceContractInformation.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/ServiceContractInformation.cs
@@ -13,6 +13,8 @@ namespace MGR.AsyncContract.SourceGenerator
         public string RootNamespace { get; }
         public string ServiceName { get; }
 
+        public string GenerateActionValueForMethod(string methodName) => $@"{RootNamespace}/{ServiceName}/{methodName}";
+
         public static ServiceContractInformation Parse(AttributeData serviceContractAttribute, string interfaceName)
         {
             string rootNamespace = "http://tempuri.org";
@@ -21,11 +23,11 @@ namespace MGR.AsyncContract.SourceGenerator
             {
                 if (argument.Key == "Namespace")
                 {
-                    rootNamespace = argument.Value.GetValue();
+                    rootNamespace = argument.Value.GetValue().Trim('"');
                 }
                 if (argument.Key == "Name")
                 {
-                    serviceName = argument.Value.GetValue();
+                    serviceName = argument.Value.GetValue().Trim('"');
                 }
             }
             return new ServiceContractInformation(rootNamespace, serviceName);

--- a/src/MGR.AsyncContract.SourceGenerator/ServiceContractSyntaxReceiver.cs
+++ b/src/MGR.AsyncContract.SourceGenerator/ServiceContractSyntaxReceiver.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MGR.AsyncContract.SourceGenerator
+{
+    internal sealed class ServiceContractSyntaxReceiver : ISyntaxReceiver
+    {
+        public List<InterfaceDeclarationSyntax> Targets { get; } = new();
+
+        public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+        {
+            if (syntaxNode is InterfaceDeclarationSyntax interfaceDeclarationSyntax)
+            {
+                if (interfaceDeclarationSyntax.AttributeLists.Count > 0
+                    && interfaceDeclarationSyntax.AttributeLists
+                        .SelectMany(attrList => attrList.Attributes)
+                        .Any(attr => attr.IsServiceContract()))
+                {
+                    Targets.Add(interfaceDeclarationSyntax);
+                }
+            }
+        }
+    }
+}

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.Generate.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.Generate.cs
@@ -85,61 +85,75 @@ namespace MGR.AsyncContract.SourceGenerator.UnitTests
 
             public static class Data
             {
+                private const string InterfaceDeclaration = @"public interface IService
+{
+}";
+                private const string AsyncInterfaceDeclaration = @"public interface IServiceAsync
+{
+}";
                 private static readonly string ExpectedFindAttributedServiceContractsWithName = @"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
 [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")]
-public interface IServiceAsync
-{
-}
+" + AsyncInterfaceDeclaration + @"
 ";
                 private static readonly string ExpectedFindAttributedServiceContractsWithNameAndSessionMode = @"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
 [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"", SessionMode = (System.ServiceModel.SessionMode)1)]
-public interface IServiceAsync
-{
-}
+" + AsyncInterfaceDeclaration + @"
 ";
                 private static readonly string ExpectedFindAttributedServiceContractsWithoutName = @"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
 [System.ServiceModel.ServiceContractAttribute()]
-public interface IServiceAsync
-{
-}
+" + AsyncInterfaceDeclaration + @"
 ";
 
                 public static TheoryData<string, string> FindAttributedServiceContractsWithName { get; } = new()
                 {
                     { @"using System.ServiceModel;
 [ServiceContract(Name = ""TestService"")]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithName },
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithName },
                     { @"[System.ServiceModel.ServiceContract(Name = ""TestService"")]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithName },
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithName },
                     { @"using System.ServiceModel;
 [ServiceContractAttribute(Name = ""TestService"")]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithName },
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithName },
                     { @"[System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithName }
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithName }
                 };
                 public static TheoryData<string, string> FindAttributedServiceContractsWithNameAndSessionMode { get; } = new()
                 {
                     { @"using System.ServiceModel;
 [ServiceContract(Name = ""TestService"", SessionMode = SessionMode.Required)]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithNameAndSessionMode },
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithNameAndSessionMode },
                     { @"[System.ServiceModel.ServiceContract(Name = ""TestService"", SessionMode = System.ServiceModel.SessionMode.Required)]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithNameAndSessionMode },
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithNameAndSessionMode },
                     { @"using System.ServiceModel;
-[ServiceContractAttribute(Name = ""TestService"", SessionMode = SessionMode.Required)]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithNameAndSessionMode },
-                    { @"[System.ServiceModel.ServiceContractAttribute(Name = ""TestService"", SessionMode = System.ServiceModel.SessionMode.Required)]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithNameAndSessionMode }
+[ServiceContractAttribute(Name = ""TestService"", SessionMode = (SessionMode)1)]
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithNameAndSessionMode },
+                    { @"[System.ServiceModel.ServiceContractAttribute(Name = ""TestService"", SessionMode = (System.ServiceModel.SessionMode)1)]
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithNameAndSessionMode }
                 };
                 public static TheoryData<string, string> FindAttributedServiceContractsWithoutName { get; } = new()
                 {
                     { @"using System.ServiceModel;
-[ServiceContract] public interface IService { }", ExpectedFindAttributedServiceContractsWithoutName },
+[ServiceContract]
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithoutName },
                     { @"[System.ServiceModel.ServiceContract]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithoutName },
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithoutName },
                     { @"using System.ServiceModel;
-[ServiceContractAttribute] public interface IService { }", ExpectedFindAttributedServiceContractsWithoutName },
+[ServiceContractAttribute]
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithoutName },
                     { @"[System.ServiceModel.ServiceContractAttribute]
-public interface IService { }", ExpectedFindAttributedServiceContractsWithoutName }
+" + InterfaceDeclaration + @"
+", ExpectedFindAttributedServiceContractsWithoutName }
                 };
             }
         }

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.Generate.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.Generate.cs
@@ -91,15 +91,15 @@ namespace MGR.AsyncContract.SourceGenerator.UnitTests
                 private const string AsyncInterfaceDeclaration = @"public interface IServiceAsync
 {
 }";
-                private static readonly string ExpectedFindAttributedServiceContractsWithName = @"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
+                private static readonly string ExpectedFindAttributedServiceContractsWithName = @"[System.CodeDom.Compiler.GeneratedCode(""" + nameof(AsyncContractSourceGenerator) + @""", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
 [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")]
 " + AsyncInterfaceDeclaration + @"
 ";
-                private static readonly string ExpectedFindAttributedServiceContractsWithNameAndSessionMode = @"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
+                private static readonly string ExpectedFindAttributedServiceContractsWithNameAndSessionMode = @"[System.CodeDom.Compiler.GeneratedCode(""" + nameof(AsyncContractSourceGenerator) + @""", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
 [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"", SessionMode = (System.ServiceModel.SessionMode)1)]
 " + AsyncInterfaceDeclaration + @"
 ";
-                private static readonly string ExpectedFindAttributedServiceContractsWithoutName = @"[System.CodeDom.Compiler.GeneratedCode(""AsyncContractSourceGenerator"", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
+                private static readonly string ExpectedFindAttributedServiceContractsWithoutName = @"[System.CodeDom.Compiler.GeneratedCode(""" + nameof(AsyncContractSourceGenerator) + @""", """ + typeof(AsyncContractSourceGenerator).Assembly.GetName().Version + @""")]
 [System.ServiceModel.ServiceContractAttribute()]
 " + AsyncInterfaceDeclaration + @"
 ";

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.Generate.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.Generate.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Linq;
+using System.ServiceModel;
+using Xunit;
+
+namespace MGR.AsyncContract.SourceGenerator.UnitTests
+{
+    public partial class InterfaceGeneratorTests
+    {
+        public class Generate
+        {
+            [Theory]
+            [MemberData(nameof(Data.FindAttributedServiceContracts), MemberType = typeof(Data))]
+            public void Should_Return_Interface_Name_With_Async(string interfaceCode)
+            {
+                var expected = @"public interface IServiceAsync
+{
+}";
+                var sourceSyntaxTree = CSharpSyntaxTree.ParseText(interfaceCode);
+                var references = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(_ => !_.IsDynamic && !string.IsNullOrWhiteSpace(_.Location))
+                    .Select(_ => MetadataReference.CreateFromFile(_.Location))
+                    .Concat(new[] { MetadataReference.CreateFromFile(typeof(ServiceContractAttribute).Assembly.Location) });
+
+                var compilation = CSharpCompilation.Create(
+                    "generator",
+                    new[] { sourceSyntaxTree },
+                    references,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+                var sut = new InterfaceGenerator(compilation);
+                var receiver = new ServiceContractSyntaxReceiver();
+
+                foreach (var node in sourceSyntaxTree.GetRoot().DescendantNodes(descendIntoChildren: _ => true))
+                {
+                    receiver.OnVisitSyntaxNode(node);
+                }
+                var interfaceDeclaration = receiver.Targets.First();
+
+                var actual = sut.Generate(interfaceDeclaration);
+
+                Assert.NotNull(actual);
+                Assert.Equal("IServiceAsync.g.cs", actual.TargetName);
+                Assert.Equal(expected, actual.SourceCode);
+            }
+            public static class Data
+            {
+                public static TheoryData<string> FindAttributedServiceContracts { get; } = new()
+                {
+                    { @" [ServiceContract] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContract] public interface IService { }" },
+                    { @" [ServiceContractAttribute] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute] public interface IService { }" },
+                    { @" [ServiceContract(Name = ""TestService"")] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContract(Name = ""TestService"")] public interface IService { }" },
+                    { @" [ServiceContractAttribute(Name = ""TestService"")] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")] public interface IService { }" },
+                };
+            }
+        }
+    }
+}

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MGR.AsyncContract.SourceGenerator.UnitTests
+{
+    public partial class InterfaceGeneratorTests
+    {
+    }
+}

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/InterfaceGeneratorTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MGR.AsyncContract.SourceGenerator.UnitTests
+﻿namespace MGR.AsyncContract.SourceGenerator.UnitTests
 {
     public partial class InterfaceGeneratorTests
     {

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MGR.AsyncContract.SourceGenerator.UnitTests.csproj
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MGR.AsyncContract.SourceGenerator.UnitTests.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+      <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+      <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net461;$(TargetFrameworks)</TargetFrameworks>
+      <IsPackable>false</IsPackable>
+      <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,10 +14,19 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="xunit.runner.visualstudio"
+                        Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MGR.AsyncContract.SourceGenerator\MGR.AsyncContract.SourceGenerator.csproj" />
   </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+        <Reference Include="System.ServiceModel" />
+    </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+        <PackageReference Include="System.ServiceModel.Primitives"
+                          Version="4.8.1" />
+    </ItemGroup>
 </Project>

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.Generate.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.Generate.cs
@@ -31,7 +31,64 @@ public interface ITest
                 Assert.Equal(expected, actual);
             }
             [Fact]
-            public void Should_Generate_Method_With_OperationContract()
+            public void Should_Generate_Method_With_OperationContract_And_Void_NoParameter()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    [OperationContract()]
+    void { MethodName }();
+}}
+";
+                var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
+System.Threading.Tasks.Task { MethodName }Async();";
+                var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+            [Fact]
+            public void Should_Generate_Method_With_OperationContract_And_Void_Parameter()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    [OperationContract()]
+    void { MethodName }(int param1);
+}}
+";
+                var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
+System.Threading.Tasks.Task { MethodName }Async(int param1);";
+                var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+            [Fact]
+            public void Should_Generate_Method_With_OperationContract_And_Void_Multiple_Parameters()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    [OperationContract()]
+    void { MethodName }(int param1, List<string> param2);
+}}
+";
+                var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
+System.Threading.Tasks.Task { MethodName }Async(int param1, List<string> param2);";
+                var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+            [Fact]
+            public void Should_Generate_Method_With_OperationContract_And_ReturnType_NoParameter()
             {
                 var interfaceCode = $@"using System.ServiceModel;
 [ServiceContract]
@@ -42,8 +99,45 @@ public interface ITest
 }}
 ";
                 var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
-                System.Threading.Tasks.Task<int> { MethodName }Async();}}
+System.Threading.Tasks.Task<int> { MethodName }Async();";
+                var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+            [Fact]
+            public void Should_Generate_Method_With_OperationContract_And_ReturnType_Parameter()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    [OperationContract()]
+    int { MethodName }(int param1);
+}}
 ";
+                var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
+System.Threading.Tasks.Task<int> { MethodName }Async(int param1);";
+                var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+            [Fact]
+            public void Should_Generate_Method_With_OperationContract_And_ReturnType_Multiple_Parameters()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    [OperationContract()]
+    int { MethodName }(int param1, List<string> param2);
+}}
+";
+                var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
+System.Threading.Tasks.Task<int> { MethodName }Async(int param1, List<string> param2);";
                 var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
 
                 var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.Generate.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.Generate.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Linq;
+using System.ServiceModel;
+using Xunit;
+
+namespace MGR.AsyncContract.SourceGenerator.UnitTests
+{
+    public partial class MethodGeneratorTests
+    {
+        public class Generate
+        {
+            private const string MethodName = "GetValue";
+            [Fact]
+            public void Should_Not_Generate_Method_Without_OperationContract()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    int { MethodName }();
+}}
+";
+                var expected = "";
+                 var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+            [Fact]
+            public void Should_Generate_Method_With_OperationContract()
+            {
+                var interfaceCode = $@"using System.ServiceModel;
+[ServiceContract]
+public interface ITest
+{{
+    [OperationContract()]
+    int { MethodName }();
+}}
+";
+                var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
+                System.Threading.Tasks.Task<int> { MethodName }Async();}}
+";
+                var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
+
+                var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
+
+                Assert.Equal(expected, actual);
+            }
+
+            private (MethodGenerator, SemanticModel, MethodDeclarationSyntax) CreateMethodGeneratorAndMethodDeclarationFromSourceCode(string sourceCode)
+            {
+                var (compilation, sourceSyntaxTree) = CreateCompilationAndSyntaxTreeFromSourceCode(sourceCode);
+                var receiver = new ServiceContractSyntaxReceiver();
+                foreach (var node in sourceSyntaxTree.GetRoot().DescendantNodes(descendIntoChildren: _ => true))
+                {
+                    receiver.OnVisitSyntaxNode(node);
+                }
+                var interfaceDeclaration = receiver.Targets.First();
+                var methodDeclaration = interfaceDeclaration.Members.OfType<MethodDeclarationSyntax>()
+                    .First(method => method.Identifier.ValueText == MethodName);
+                var methodGenerator = new MethodGenerator(compilation, new(compilation));
+
+                var semanticModel = compilation.GetSemanticModel(interfaceDeclaration.SyntaxTree);
+
+                return (methodGenerator, semanticModel, methodDeclaration);
+            }
+            private (Compilation, SyntaxTree) CreateCompilationAndSyntaxTreeFromSourceCode(string sourceCode)
+            {
+                var sourceSyntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+                var references = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(_ => !_.IsDynamic && !string.IsNullOrWhiteSpace(_.Location))
+                    .Select(_ => MetadataReference.CreateFromFile(_.Location))
+                    .Concat(new[] { MetadataReference.CreateFromFile(typeof(ServiceContractAttribute).Assembly.Location) });
+
+                var compilation = CSharpCompilation.Create(
+                    "generator",
+                    new[] { sourceSyntaxTree },
+                    references,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                return (compilation, sourceSyntaxTree);
+            }
+        }
+    }
+}

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.Generate.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.Generate.cs
@@ -72,6 +72,7 @@ System.Threading.Tasks.Task { MethodName }Async(int param1);";
             public void Should_Generate_Method_With_OperationContract_And_Void_Multiple_Parameters()
             {
                 var interfaceCode = $@"using System.ServiceModel;
+using System.Collections.Generic;
 [ServiceContract]
 public interface ITest
 {{
@@ -80,7 +81,7 @@ public interface ITest
 }}
 ";
                 var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
-System.Threading.Tasks.Task { MethodName }Async(int param1, List<string> param2);";
+System.Threading.Tasks.Task { MethodName }Async(int param1, System.Collections.Generic.List<string> param2);";
                 var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
 
                 var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));
@@ -129,15 +130,17 @@ System.Threading.Tasks.Task<int> { MethodName }Async(int param1);";
             public void Should_Generate_Method_With_OperationContract_And_ReturnType_Multiple_Parameters()
             {
                 var interfaceCode = $@"using System.ServiceModel;
+using System.Collections.Generic
+using System.IO;
 [ServiceContract]
 public interface ITest
 {{
     [OperationContract()]
-    int { MethodName }(int param1, List<string> param2);
+    int { MethodName }(int param1, List<Stream> param2);
 }}
 ";
                 var expected = $@"[System.ServiceModel.OperationContractAttribute(Action = ""http://tempuri.org/ITest/{ MethodName }"")]
-System.Threading.Tasks.Task<int> { MethodName }Async(int param1, List<string> param2);";
+System.Threading.Tasks.Task<int> { MethodName }Async(int param1, System.Collections.Generic.List<System.IO.Stream> param2);";
                 var (sut, semanticModel, methodDeclaration) = CreateMethodGeneratorAndMethodDeclarationFromSourceCode(interfaceCode);
 
                 var actual = sut.Generate(semanticModel, methodDeclaration, new ServiceContractInformation("http://tempuri.org", "ITest"));

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/MethodGeneratorTests.cs
@@ -1,0 +1,6 @@
+﻿namespace MGR.AsyncContract.SourceGenerator.UnitTests
+{
+    public partial class MethodGeneratorTests
+    {
+    }
+}

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/ServiceContractSyntaxReceiverTests.OnVisitSyntaxNode.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/ServiceContractSyntaxReceiverTests.OnVisitSyntaxNode.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MGR.AsyncContract.SourceGenerator.UnitTests
+{
+    public partial class ServiceContractSyntaxReceiverTests
+    {
+        public class OnVisitSyntaxNode
+        {
+            [Theory]
+            [MemberData(nameof(Data.FindAttributedServiceContracts), MemberType = typeof(Data))]
+            public async Task Should_Find_ServiceContract_With_All_Attributes_Syntaxes(string code)
+            {
+                var rootSyntaxNode = await SyntaxFactory.ParseSyntaxTree(code)
+                           .GetRootAsync()
+                           .ConfigureAwait(false);
+
+                var receiver = new ServiceContractSyntaxReceiver();
+                foreach (var node in rootSyntaxNode.DescendantNodes(descendIntoChildren: _ => true))
+                {
+                    receiver.OnVisitSyntaxNode(node);
+                }
+
+                _ = Assert.Single(receiver.Targets);
+            }
+            [Fact]
+            public async Task Should_Not_Find_ServiceContract_If_Attribute_Is_Missing()
+            {
+                var rootSyntaxNode = await SyntaxFactory.ParseSyntaxTree(" public interface IService { }")
+                           .GetRootAsync()
+                           .ConfigureAwait(false);
+
+                var receiver = new ServiceContractSyntaxReceiver();
+                foreach (var node in rootSyntaxNode.DescendantNodes(descendIntoChildren: _ => true))
+                {
+                    receiver.OnVisitSyntaxNode(node);
+                }
+
+                Assert.Empty(receiver.Targets);
+            }
+            [Theory]
+            [MemberData(nameof(Data.DontFindAttributedServiceContracts), MemberType = typeof(Data))]
+            public async Task Should_Not_Find_ServiceContract_If_Type_Is_Not_Interface(string code)
+            {
+                var rootSyntaxNode = await SyntaxFactory.ParseSyntaxTree(code)
+                           .GetRootAsync()
+                           .ConfigureAwait(false);
+
+                var receiver = new ServiceContractSyntaxReceiver();
+                foreach (var node in rootSyntaxNode.DescendantNodes(descendIntoChildren: _ => true))
+                {
+                    receiver.OnVisitSyntaxNode(node);
+                }
+
+                Assert.Empty(receiver.Targets);
+            }
+
+            public static class Data
+            {
+                public static TheoryData<string> FindAttributedServiceContracts { get; } = new()
+                {
+                    { @" [ServiceContract] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContract] public interface IService { }" },
+                    { @" [ServiceContractAttribute] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute] public interface IService { }" },
+                    { @" [ServiceContract(Name = ""TestService"")] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContract(Name = ""TestService"")] public interface IService { }" },
+                    { @" [ServiceContractAttribute(Name = ""TestService"")] public interface IService { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")] public interface IService { }" },
+                };
+                public static TheoryData<string> DontFindAttributedServiceContracts { get; } = new()
+                {
+                    { @" [ServiceContract] public class Service { }" },
+                    { @" [System.ServiceModel.ServiceContract] public class Service { }" },
+                    { @" [ServiceContractAttribute] public class Service { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute] public class Service { }" },
+                    { @" [ServiceContract(Name = ""TestService"")] public class Service { }" },
+                    { @" [System.ServiceModel.ServiceContract(Name = ""TestService"")] public class Service { }" },
+                    { @" [ServiceContractAttribute(Name = ""TestService"")] public class Service { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")] public class Service { }" },
+                    { @" [ServiceContract] public struct Service { }" },
+                    { @" [System.ServiceModel.ServiceContract] public struct Service { }" },
+                    { @" [ServiceContractAttribute] public struct Service { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute] public struct Service { }" },
+                    { @" [ServiceContract(Name = ""TestService"")] public struct Service { }" },
+                    { @" [System.ServiceModel.ServiceContract(Name = ""TestService"")] public struct Service { }" },
+                    { @" [ServiceContractAttribute(Name = ""TestService"")] public struct Service { }" },
+                    { @" [System.ServiceModel.ServiceContractAttribute(Name = ""TestService"")] public struct Service { }" },
+                };
+            }
+        }
+    }
+}

--- a/tests/MGR.AsyncContract.SourceGenerator.UnitTests/ServiceContractSyntaxReceiverTests.cs
+++ b/tests/MGR.AsyncContract.SourceGenerator.UnitTests/ServiceContractSyntaxReceiverTests.cs
@@ -1,0 +1,6 @@
+﻿namespace MGR.AsyncContract.SourceGenerator.UnitTests
+{
+    public partial class ServiceContractSyntaxReceiverTests
+    {
+    }
+}


### PR DESCRIPTION
The generated interface contains, for each interface marked with attribute `[ServiceContract]`:
- all attributes at the interface level
- attribute `GeneratedCode` is added
- all methods marked with attribute `[OperationContract]` are generated:
  - all attributes are included
  - return type is converted to its `Task` equivalent
  - name of the method is appended by `Async`
  - parameters of the method are included